### PR TITLE
Change Architect label on MainTabDef to Costruire

### DIFF
--- a/DefInjected/MainTabDef/MainTabs.xml
+++ b/DefInjected/MainTabDef/MainTabs.xml
@@ -3,7 +3,7 @@
 
   <Inspect.label>esaminare</Inspect.label>
 
-  <Architect.label>Architto</Architect.label>
+  <Architect.label>Costruire</Architect.label>
   <Architect.description>Definire, dove e cosa costruiscono i coloni, la semina, la conservazione, ect...</Architect.description>
 
   <Work.label>Lavoro</Work.label>


### PR DESCRIPTION
Change Architect label to the word that describes the action being performed.
The old word "Architto" seems a spelling error.