### PR TITLE
Fix Architect Term

### DIFF
--- a/DefInjected/MainTabDef/MainTabs.xml
+++ b/DefInjected/MainTabDef/MainTabs.xml
@@ -3,7 +3,7 @@
 
   <Inspect.label>esaminare</Inspect.label>
 
-  <Architect.label>Architto</Architect.label>
+  <Architect.label>Architetto</Architect.label>
   <Architect.description>Definire, dove e cosa costruiscono i coloni, la semina, la conservazione, ect...</Architect.description>
 
   <Work.label>Lavoro</Work.label>

--- a/DefInjected/MainTabDef/MainTabs.xml
+++ b/DefInjected/MainTabDef/MainTabs.xml
@@ -3,7 +3,7 @@
 
   <Inspect.label>esaminare</Inspect.label>
 
-  <Architect.label>Architetto</Architect.label>
+  <Architect.label>Progettazione</Architect.label>
   <Architect.description>Definire, dove e cosa costruiscono i coloni, la semina, la conservazione, ect...</Architect.description>
 
   <Work.label>Lavoro</Work.label>


### PR DESCRIPTION
Architto has a typo, the right word is Architetto, but I think Progettazione suits better for that menu item